### PR TITLE
[BUGFIX] add normalized cache-dir to composer.json and gitlab matrixes versions as strings

### DIFF
--- a/bin/mediatis-typo3-coding-standards-setup
+++ b/bin/mediatis-typo3-coding-standards-setup
@@ -25,11 +25,11 @@ $examplePackagePath = 'example-extension';
 $supportedPackageVersions = [
     'php' => [
         'packageKeys' => ['php'],
-        'versions' => [8.1, 8.2],
+        'versions' => ['8.1', '8.2'],
     ],
     'typo3' => [
         'packageKeys' => ['typo3/cms', 'typo3/cms-core'],
-        'versions' => [11.5, 12.4],
+        'versions' => ['11.5', '12.4'],
     ],
 ];
 

--- a/example-extension/composer.json
+++ b/example-extension/composer.json
@@ -47,6 +47,7 @@
             "typo3/cms-composer-installers": true
         },
         "bin-dir": ".Build/bin",
+		"cache-dir": "./cache/composer",
         "vendor-dir": ".Build/vendor"
     },
     "extra": {


### PR DESCRIPTION
- Gitlab requires the matrixes to be strings or the CI yaml does not validate. I think GitHub does not care.
- The added cache-dir via before_script modifies the composer.json file of the package during CI action, but does not normalize it, which causes the followup "composer normalize" to fail. That's why we add the cache-dir attribute to the example composer.json so that it can be normalized manually.