### PR TITLE
Add PHP 8.5 to CI matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,7 @@ jobs:
                     - '8.2'
                     - '8.3'
                     - '8.4'
+                    - '8.5'
         steps:
             -
                 name: Checkout
@@ -84,6 +85,7 @@ jobs:
                     - '8.2'
                     - '8.3'
                     - '8.4'
+                    - '8.5'
         steps:
             -
                 name: Checkout

--- a/bin/mediatis-typo3-coding-standards-setup
+++ b/bin/mediatis-typo3-coding-standards-setup
@@ -25,11 +25,11 @@ $examplePackagePath = 'example-extension';
 $supportedPackageVersions = [
     'php' => [
         'packageKeys' => ['php'],
-        'versions' => [8.2, 8.3],
+        'versions' => [8.2, 8.3, 8.4, 8.5],
     ],
     'typo3' => [
         'packageKeys' => ['typo3/cms', 'typo3/cms-core'],
-        'versions' => [12.4, 13.4],
+        'versions' => [12.4, 13.4, 14.2],
     ],
 ];
 

--- a/src/Typo3CodingStandardsSetup.php
+++ b/src/Typo3CodingStandardsSetup.php
@@ -96,6 +96,8 @@ class Typo3CodingStandardsSetup extends CodingStandardsSetup
         $phpVersion = match ($phpVersions[0]) {
             8.2 => 'PHP_82',
             8.3 => 'PHP_83',
+            8.4 => 'PHP_84',
+            8.5 => 'PHP_85',
             default => throw new Exception('Unable to set up rector due to version mismatch. Supported PHP versions are: ' . implode(', ', $this->supportedPackageVersions['php']['versions'])),
         };
         $typo3Versions = $this->getDependencyVersionConstraintsFromComposerData('typo3', 'major');


### PR DESCRIPTION
Extends CI code-quality + code-tests jobs to include PHP 8.5.