### PR TITLE
Correct CI template for new TYPO3 extensions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,7 +57,7 @@ jobs:
                 uses: actions/checkout@v3
             -
                 name: 'Run Trivy vulnerability scanner in repo mode'
-                uses: aquasecurity/trivy-action@0.36.0
+                uses: aquasecurity/trivy-action@v0.36.0
                 with:
                     scan-type: fs
                     scan-ref: .

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,7 +57,7 @@ jobs:
                 uses: actions/checkout@v3
             -
                 name: 'Run Trivy vulnerability scanner in repo mode'
-                uses: aquasecurity/trivy-action@0.20.0
+                uses: aquasecurity/trivy-action@0.36.0
                 with:
                     scan-type: fs
                     scan-ref: .

--- a/example-extension/.gitlab-ci.yml
+++ b/example-extension/.gitlab-ci.yml
@@ -22,7 +22,7 @@ code-quality:
     key:
       files:
         - composer.lock
-      prefix: 'php${php_version}-typo3{typo3_version}-'
+      prefix: 'php${php_version}-typo3${typo3_version}-'
     paths:
       - ./cache/composer
   before_script:
@@ -33,7 +33,6 @@ code-quality:
     - 'chmod +x /usr/local/bin/composer'
     - 'composer config cache-dir ./cache/composer'
     - 'cp /usr/local/etc/php/php.ini-production /usr/local/etc/php/php.ini'
-    - 'awk ''/^error_reporting = E_ALL/{print "error_reporting = E_ALL & ~E_DEPRECATED"; next}1'' /usr/local/etc/php/php.ini > temp.ini && mv temp.ini /usr/local/etc/php/php.ini'
     - 'composer require typo3/cms-core ^${typo3_version} --no-progress --ignore-platform-req=ext-intl'
     - 'composer install --no-progress --ignore-platform-req=ext-intl'
   image: 'php:${php_version}'
@@ -49,7 +48,7 @@ code-tests:
     key:
       files:
         - composer.lock
-      prefix: 'php${php_version}-typo3{typo3_version}-'
+      prefix: 'php${php_version}-typo3${typo3_version}-'
     paths:
       - ./cache/composer
   before_script:
@@ -57,11 +56,11 @@ code-tests:
     - 'apt-get update -yqq'
     - 'apt-get install git libzip-dev unzip parallel libxml2-utils wget wait-for-it libicu-dev -yqq'
     - 'docker-php-ext-install mysqli && docker-php-ext-enable mysqli'
+    - 'pecl install pcov && docker-php-ext-enable pcov'
     - 'php -r "readfile(''http://getcomposer.org/installer'');" | php -- --install-dir=/usr/local/bin/ --filename=composer'
     - 'chmod +x /usr/local/bin/composer'
     - 'composer config cache-dir ./cache/composer'
     - 'cp /usr/local/etc/php/php.ini-production /usr/local/etc/php/php.ini'
-    - 'awk ''/^error_reporting = E_ALL/{print "error_reporting = E_ALL & ~E_DEPRECATED"; next}1'' /usr/local/etc/php/php.ini > temp.ini && mv temp.ini /usr/local/etc/php/php.ini'
     - 'composer require typo3/cms-core ^${typo3_version} --no-progress --ignore-platform-req=ext-intl'
     - 'composer install --no-progress --ignore-platform-req=ext-intl'
   image: 'php:${php_version}'

--- a/example-extension/.gitlab-ci.yml
+++ b/example-extension/.gitlab-ci.yml
@@ -56,7 +56,6 @@ code-tests:
     - 'apt-get update -yqq'
     - 'apt-get install git libzip-dev unzip parallel libxml2-utils wget wait-for-it libicu-dev -yqq'
     - 'docker-php-ext-install mysqli && docker-php-ext-enable mysqli'
-    - 'pecl install pcov && docker-php-ext-enable pcov'
     - 'php -r "readfile(''http://getcomposer.org/installer'');" | php -- --install-dir=/usr/local/bin/ --filename=composer'
     - 'chmod +x /usr/local/bin/composer'
     - 'composer config cache-dir ./cache/composer'
@@ -68,7 +67,7 @@ code-tests:
   services:
     - mariadb:10
   script:
-    - 'composer ci:coverage'
+    - 'composer ci:dynamic'
 'semgrep':
   image: 'semgrep/semgrep'
   script: 'semgrep scan --config auto --error .'

--- a/example-extension/composer.json
+++ b/example-extension/composer.json
@@ -24,7 +24,8 @@
         "typo3/cms-core": "^13.4 || ^14.2"
     },
     "require-dev": {
-        "mediatis/typo3-coding-standards": "^3.0"
+        "mediatis/typo3-coding-standards": "^3.0",
+        "typo3/testing-framework": "^8.2.7 || ^9.0"
     },
     "conflict": {
         "typo3/class-alias-loader": "< 1.1.0"
@@ -77,7 +78,7 @@
         "ci:coverage:functional": [
             "@ci:tests:create-directories",
             "@coverage:create-directories",
-            ".Build/bin/phpunit -c .Build/vendor/typo3/testing-framework/Resources/Core/Build/FunctionalTests.xml --include-path Classes --coverage-php=.Build/coverage/functional.cov Tests/Functional"
+            ".Build/bin/phpunit -c .Build/vendor/typo3/testing-framework/Resources/Core/Build/FunctionalTests.xml --coverage-filter Classes --coverage-php=.Build/coverage/functional.cov Tests/Functional"
         ],
         "ci:coverage:merge": [
             "@coverage:create-directories",
@@ -85,7 +86,7 @@
         ],
         "ci:coverage:unit": [
             "@coverage:create-directories",
-            ".Build/bin/phpunit -c .Build/vendor/typo3/testing-framework/Resources/Core/Build/UnitTests.xml --include-path Classes --coverage-php=.Build/coverage/unit.cov Tests/Unit"
+            ".Build/bin/phpunit -c .Build/vendor/typo3/testing-framework/Resources/Core/Build/UnitTests.xml --coverage-filter Classes --coverage-php=.Build/coverage/unit.cov Tests/Unit"
         ],
         "ci:dynamic": [
             "@ci:tests"


### PR DESCRIPTION
## Summary

Several issues in \`example-extension/\` made fresh extensions fail their first CI run after \`mediatis-typo3-coding-standards-setup\`:

1. **\`{typo3_version}\` missing leading \`\$\`** in the cache prefix of both \`code-quality\` and \`code-tests\`. GitLab does not error on the unexpanded variable, it just collapses every matrix leg into the same cache bucket — silent cache poisoning across TYPO3 versions.
2. **Global \`E_DEPRECATED\` suppression** in \`php.ini\` defeats the purpose of running the matrix against PHP 8.4 / 8.5: deprecation warnings (which become fatal in the next major) are precisely what the matrix should be surfacing.
3. **\`code-tests\` had no coverage driver**. \`composer ci:coverage\` calls \`phpunit --coverage-php\`, and the testing-framework's \`phpunit.xml\` ships with \`failOnWarning=true\`, so the missing-driver warning bails the whole job. Added \`pecl install pcov && docker-php-ext-enable pcov\`.
4. **\`--include-path Classes\` is not a coverage filter** in PHPUnit 11. Without a coverage filter (or \`<source>\` in phpunit.xml) PHPUnit warns _"No filter is configured"_ and \`failOnWarning\` bails. Switched both \`ci:coverage:unit\` and \`ci:coverage:functional\` scripts to \`--coverage-filter Classes\`.
5. **\`typo3/testing-framework\` was not declared** in \`require-dev\` — it was arriving only transitively through \`mediatis/typo3-coding-standards\`. If that upstream ever bounds or drops it, all tests of any consuming extension break at dep-resolution time. Declared explicitly.

These problems were observed end-to-end on a real new extension setup against the v3 setup pipeline.

## Test plan

- [ ] Run \`mediatis-typo3-coding-standards-setup\` on a clean extension and confirm the generated files are correct.
- [ ] Run \`composer ci\` and \`composer ci:coverage\` against the GitLab pipeline (PHP 8.2 / 8.3 / 8.4 / 8.5 × TYPO3 13.4 / 14.2) and confirm all matrix legs are green.
- [ ] Confirm that \`failOnDeprecation\` still triggers on actual deprecations (e.g. an implicitly nullable parameter on PHP 8.4+).